### PR TITLE
Error response at AuthContext cause infinite re-render on error routes.

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -110,7 +110,7 @@ async function signOut(req, res) {
 		res.cookie("token", "", { maxAge: 0 });
 	}
 
-	res.end();
+	res.status(200).json({ success: true });
 }
 
 const generateToken = (data) => {

--- a/social/src/contexts/AuthContext.jsx
+++ b/social/src/contexts/AuthContext.jsx
@@ -4,7 +4,7 @@ import { fetchAction } from "../components/api/api";
 import { useErrorStatus } from "./ErrorContext";
 
 export const AuthContext = createContext(null);
-const preventRoutes = ['/login', '/register', '/signout'];
+const preventRoutes = ['/login', '/register', '/signout', '/404', '/500'];
 
 export default function AuthContextProvider({ children }) {
 	const {setErrorStatusCode} = useErrorStatus();
@@ -97,9 +97,13 @@ export default function AuthContextProvider({ children }) {
 	}
 
 	async function signOut() {
-		await fetchAction({     
-			path: 'signout',			
+		const response = await fetchAction({
+			path: 'signout',
 		});
+
+		if(response.error && response.code) {			
+			return setErrorStatusCode(response.code)
+        }
 	}
 
 	return (


### PR DESCRIPTION
# Description

Add error routes to AuthContext prevent routes exception and treat signout route response to graceful error handling.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code